### PR TITLE
setup: add pyproject.toml

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,0 @@
-select = ["ALL"]
-ignore = ["ANN101", "ANN102", "D203", "D211", "D212", "D213", "D401", "INP001", "UP009", "S101", "BLE001", "SLF001", "PERF203", "RUF015", "TD", "FIX"]
-
-exclude = ["docs"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021-2024 Graz University of Technology.
+# Copyright (C) 2021-2026 Graz University of Technology.
 #
 # repository-cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -345,4 +345,5 @@ nitpick_ignore = [
     ("py:class", "Record"),
     ("py:class", "RecordItem"),
     ("py:class", "celery.local.celery.local"),
+    ("py:class", "invenio_records_resources.services.records.results.RecordItem"),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,34 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+  "D203", "D211", "D212", "D213",
+  "E501",
+  "FA100", "FA102",
+  "FIX002",
+  "INP001",
+  "N999",
+  "PERF203",
+  "PLR0913",
+  "S101",
+  "TD002", "TD003",
+  "TID252",
+  "UP009",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**.py" = [
+  "ANN201",
+]
+
+[tool.mypy]
+extra_checks = true
+strict = true
+strict_bytes = true
+strict_equality = true
+follow_untyped_imports = true
+disallow_any_generics = false
+python_executable = ".venv/bin/python"

--- a/repository_cli/click_options.py
+++ b/repository_cli/click_options.py
@@ -7,7 +7,6 @@
 
 """Commonly used options for CLI commands."""
 
-
 from collections.abc import Callable
 from typing import Any, TypeVar
 

--- a/repository_cli/generate_commands.py
+++ b/repository_cli/generate_commands.py
@@ -6,6 +6,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Build database update commands from `metadata_class`\\ es."""
+
 from functools import wraps
 from inspect import Parameter, signature
 from typing import Callable, _UnionGenericAlias

--- a/repository_cli/records.py
+++ b/repository_cli/records.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021-2024 Graz University of Technology.
+# Copyright (C) 2021-2026 Graz University of Technology.
 #
 # repository-cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/repository_cli/types.py
+++ b/repository_cli/types.py
@@ -7,7 +7,6 @@
 
 """Types."""
 
-
 from dataclasses import dataclass
 
 

--- a/repository_cli/utils.py
+++ b/repository_cli/utils.py
@@ -1,20 +1,18 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021-2024 Graz University of Technology.
+# Copyright (C) 2021-2026 Graz University of Technology.
 #
 # repository-cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Commonly used utility functions."""
-from __future__ import annotations
-
-from contextlib import suppress
-from typing import TYPE_CHECKING
 
 from celery.local import Proxy as CeleryProxy
 from flask_principal import Identity, RoleNeed
 from invenio_access.permissions import any_user, system_process
 from invenio_accounts import current_accounts
+from invenio_db import db
+from invenio_drafts_resources.records.api import Draft, Record
 from invenio_pidstore.errors import PIDUnregistered
 from invenio_rdm_records.proxies import current_rdm_records
 from invenio_rdm_records.records.api import RDMRecord
@@ -35,14 +33,9 @@ from invenio_records_marc21.records.api import Marc21Record
 from invenio_records_marc21.services.pids.tasks import (
     register_or_update_pid as marc21_register_or_update_pid,
 )
-from invenio_records_resources.records import Record
+from invenio_records_resources.services import RecordService
+from invenio_records_resources.services.records.results import RecordItem
 from sqlalchemy.orm.exc import NoResultFound
-
-if TYPE_CHECKING:
-    from invenio_db import db
-    from invenio_drafts_resources.records.api import Draft, Record
-    from invenio_records_resources.services import RecordService
-    from invenio_records_resources.services.records.results import RecordItem
 
 BELOW_CONTROLFIELD = 10
 
@@ -171,7 +164,7 @@ def get_metadata_model(
         raise RuntimeError(msg) from exc
 
 
-def get_metadata_class(data_model: str):
+def get_metadata_class(data_model: str) -> type[db.Model]:
     """Get the metadata class."""
     available_metadata_classes = {
         "lom": LOMMetadata,

--- a/repository_cli/utils.py
+++ b/repository_cli/utils.py
@@ -30,8 +30,7 @@ from invenio_records_lom.services.tasks import (
 )
 from invenio_records_lom.utils.metadata import LOMMetadata
 from invenio_records_marc21 import Marc21Metadata, current_records_marc21
-from invenio_records_marc21.records import DraftMetadata as Marc21DraftMetadata
-from invenio_records_marc21.records import RecordMetadata as Marc21RecordMetadata
+from invenio_records_marc21.records import Marc21DraftMetadata, Marc21RecordMetadata
 from invenio_records_marc21.records.api import Marc21Record
 from invenio_records_marc21.services.pids.tasks import (
     register_or_update_pid as marc21_register_or_update_pid,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021-2025 Graz University of Technology.
+# Copyright (C) 2021-2026 Graz University of Technology.
 #
 # repository-cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -29,7 +29,7 @@ zip_safe = False
 install_requires =
     click>=8.0.0
     invenio-rdm-records[opensearch2]>=4.0.0
-    invenio-records-marc21>=0.9
+    invenio-records-marc21>=0.28.0
     invenio-records-lom>=0.10
     jq>=1.4.0
     tabulate>=0.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021-2024 Graz University of Technology.
+# Copyright (C) 2021-2025 Graz University of Technology.
 #
 # repository-cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -18,6 +18,7 @@ platforms = any
 url = https://github.com/inveniosoftware/repository-cli
 classifiers =
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Development Status :: 5 - Production/Stable
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,30 +17,29 @@ author_email = info@inveniosoftware.org
 platforms = any
 url = https://github.com/inveniosoftware/repository-cli
 classifiers =
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Development Status :: 5 - Production/Stable
 
 [options]
 include_package_data = True
 packages = find:
-python_requires = >=3.12
+python_requires = >=3.14
 zip_safe = False
 install_requires =
     click>=8.0.0
-    invenio-rdm-records[opensearch2]>=4.0.0
+    invenio-rdm-records[opensearch2]>=24.0.0
     invenio-records-marc21>=0.28.0
-    invenio-records-lom>=0.10
+    invenio-records-lom>=0.20
     jq>=1.4.0
     tabulate>=0.9.0
 
 [options.extras_require]
 tests =
-    pytest-invenio>=1.4.0
-    pytest-black-ng>=0.4.0
-    invenio-app>=1.3.0
-    invenio-search[opensearch2]>=2.1.0
-    invenio-cache>=1.1.1
+    pytest-invenio>=4.0.0
+    pytest-black>=0.6.0
+    invenio-app>=3.0.0
+    invenio-search[opensearch2]>=3.0.0
+    invenio-cache>=3.0.0
     Sphinx>=7.0.0
     sphinx-click>=6.0.0
     ruff>=0.5.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,5 @@ universal = 1
 profile=black
 
 [tool:pytest]
-addopts =  --black --doctest-glob="*.rst" --doctest-modules --cov=repository_cli --cov-report=term-missing
+addopts = --black --doctest-glob="*.rst" --doctest-modules --cov=repository_cli --cov-report=term-missing
 testpaths = tests repository_cli
-

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 Graz University of Technology.
+#
+# repository-cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021-2024 Graz University of Technology.
+# Copyright (C) 2021-2025 Graz University of Technology.
 #
 # repository-cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -52,6 +52,7 @@ def fixture_app_config(app_config: dict) -> dict:
     )
     app_config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     app_config["DATADIR"] = "data"
+    app_config["THEME_FRONTPAGE"] = False
 
     return app_config
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021-2025 Graz University of Technology.
+# Copyright (C) 2021-2026 Graz University of Technology.
 #
 # repository-cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -33,6 +33,16 @@ from invenio_vocabularies.records.api import Vocabulary
 from invenio_vocabularies.records.models import VocabularyType
 
 
+@pytest.fixture(scope="module")
+def extra_entry_points() -> dict:
+    """Extra entrypoints."""
+    return {
+        "invenio_base.blueprints": [
+            "invenio_app_rdm_records = tests.mock_module:create_invenio_app_rdm_records_blueprint",
+        ],
+    }
+
+
 @pytest.fixture(scope="module", name="app_config")
 def fixture_app_config(app_config: dict) -> dict:
     """Mimic an instance's configuration."""
@@ -58,7 +68,7 @@ def fixture_app_config(app_config: dict) -> dict:
 
 
 @pytest.fixture(scope="module")
-def create_app() -> Flask:
+def create_app(entry_points: dict) -> Flask:
     """Application factory fixture."""
     return _create_api
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,9 @@ def fixture_app_config(app_config: dict) -> dict:
     app_config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     app_config["DATADIR"] = "data"
     app_config["THEME_FRONTPAGE"] = False
+    app_config["RDM_FILES_DEFAULT_QUOTA_SIZE"] = 10**10
+    app_config["RDM_FILES_DEFAULT_MAX_FILE_SIZE"] = 10**10
+    app_config["OAISERVER_ID_PREFIX"] = "repo"
 
     return app_config
 

--- a/tests/mock_module/__init__.py
+++ b/tests/mock_module/__init__.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 Graz University of Technology.
+#
+# repository-cli is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Mock module."""
+
+from flask import Blueprint, Flask
+
+
+def create_invenio_app_rdm_records_blueprint(app: Flask) -> Blueprint:
+    """Create fake invenio_app_rdm_records Blueprint akin to invenio-app-rdm's."""
+    blueprint = Blueprint(
+        "invenio_app_rdm_records",
+        __name__,
+    )
+
+    @blueprint.route("/records/<pid_value>/files/<path:filename>")
+    def record_file_download(*_: tuple, **__: dict) -> str:
+        """Fake record_file_download view function."""
+        return "<file content>"
+
+    @blueprint.route("/uploads/<pid_value>")
+    def deposit_edit(*_: tuple, **__: dict) -> str:
+        """Fake record_detail view function."""
+        return "<deposit edit>"
+
+    @blueprint.route("/records/<pid_value>")
+    def record_detail(*_: tuple, **__: dict) -> str:
+        """Fake record_detail view function."""
+        return "<record detail>"
+
+    @blueprint.route("/records/<pid_value>/latest")
+    def record_latest(*_: tuple, **__: dict) -> str:
+        """Fake record_latest view function."""
+        return "<record latest>"
+
+    @blueprint.route("/<any(doi):pid_scheme>/<path:pid_value>")
+    def record_from_pid(*_: tuple, **__: dict) -> str:
+        """Fake record_from_pid view function."""
+        return "<record from pid>"
+
+    return blueprint

--- a/tests/test_rdmrecords.py
+++ b/tests/test_rdmrecords.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021-2024 Graz University of Technology.
+# Copyright (C) 2021-2026 Graz University of Technology.
 #
 # repository-cli is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -30,7 +30,7 @@ def test_base_command(app: Flask) -> None:
     """Test base command."""
     runner = app.test_cli_runner()
     response = runner.invoke(group_records)
-    assert response.exit_code == 0
+    assert response.exit_code == 2
 
 
 def test_count_with_entries(


### PR DESCRIPTION
`pyproject.toml` is needed to build via the build-backend API
without it, the building process must be specific to `setuptools`, which precludes other backends from being used
this prevents generalizing our github-workflow to allow use of other backends (e.g. `hatchling`)